### PR TITLE
work with `uglify-js 3.x`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,46 +1,25 @@
-'use strict'
+'use strict';
 
-var fs = require('fs')
-var PassThrough = require('stream').PassThrough
-var Transform = require('stream').Transform
+var readFileSync = require('fs').readFileSync;
+var Transform = require('stream').Transform;
+var UglifyJS = require('uglify-js');
 
-if (typeof Transform === 'undefined') {
-  throw new Error('UglifyJS only supports browserify when using node >= 0.10.x')
-}
-
-var cache = {}
-module.exports = transform
-function transform(file) {
-  if (!/tools\/node\.js$/.test(file.replace(/\\/g,'/'))) return new PassThrough();
-  if (cache[file]) return makeStream(cache[file])
-  var uglify = require(file)
-  var src = 'var sys = require("util");\nvar MOZ_SourceMap = require("source-map");\nvar UglifyJS = exports;\n' + uglify.FILES.map(function (path) { return fs.readFileSync(path, 'utf8') }).join('\n')
-
-  var ast = uglify.parse(src)
-  ast.figure_out_scope()
-
-  var variables = ast.variables
-    .map(function (node, name) {
-      return name
-    })
-
-  src += '\n\n' + variables.map(function (v) { return 'exports.' + v + ' = ' + v + ';' }).join('\n') + '\n\n'
-
-  src += 'exports.AST_Node.warn_function = function (txt) { if (typeof console != "undefined" && typeof console.warn === "function") console.warn(txt) }\n\n'
-
-  src += 'exports.minify = ' + uglify.minify.toString() + ';\n\n'
-  src += 'exports.describe_ast = ' + uglify.describe_ast.toString() + ';'
-
-  cache[file] = src
-  return makeStream(src);
-}
-
-function makeStream(src) {
-  var res = new Transform();
-  res._transform = function (chunk, encoding, callback) { callback() }
-  res._flush = function (callback) {
-    res.push(src)
-    callback()
-  }
-  return res;
-}
+module.exports = function() {
+  var stream = new Transform();
+  stream._flush = function(callback) {
+    var files = {};
+    UglifyJS.FILES.forEach(function(file) {
+      files[file] = readFileSync(file, 'utf8');
+    });
+    stream.push(UglifyJS.minify(files, {
+      compress: false,
+      mangle: false,
+      wrap: 'exports'
+    }).code);
+    callback();
+  };
+  stream._transform = function(chunk, encoding, callback) {
+    callback();
+  };
+  return stream;
+};

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "uglify-to-browserify",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A transform to make UglifyJS work in browserify.",
   "keywords": [],
   "dependencies": {},
   "devDependencies": {
     "resolve": "^1.3.1",
-    "uglify-js": "~2.7.5"
+    "uglify-js": "~3.0.4"
   },
   "scripts": {
     "test": "node test/index.js"

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,7 @@ transform.on('data', function (nextData) {
     )
     var uglify = mod.exports
     var src = 'function add(firstValue, secondValue) { return firstValue + secondValue }'
-    var output = uglify.minify(src, {fromString: true}).code
+    var output = uglify.minify(src).code
     assert(src.length > 35, 'minifying should make the output nice and short')
     assert(output.length < 35, 'minifying should make the output nice and short')
     assert(Function('a,b', output + ';return add(a, b)')(40, 2) === 42, 'output code still works')


### PR DESCRIPTION
I notice that current version of `uglify-to-browserify` does not work with UglifyJS 3.

`uglify-js` now has a simplified API, and exposes `minify()` via the `uglify-js --self` build.

So this is using that functionality to generate a transformed module that would work with `browserify`.